### PR TITLE
google signIn provider issue

### DIFF
--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -21,13 +21,13 @@ model Account {
     type                     String
     provider                 String
     providerAccountId        String
-    refresh_token            String?
-    access_token             String?
+    refresh_token            String? @db.VarChar(500)
+    access_token             String? @db.VarChar(500)
     refresh_token_expires_in Int?
     expires_at               Int?
     token_type               String?
     scope                    String?
-    id_token                 String?
+    id_token                 String? @db.Text
     session_state            String?
     oauth_token_secret       String?
     oauth_token              String?


### PR DESCRIPTION
`id_token` for Google provider requires a length 1000+ chars as supposed to `VARCHAR(191)` 